### PR TITLE
refactor

### DIFF
--- a/lib/handler/factory.js
+++ b/lib/handler/factory.js
@@ -1,9 +1,8 @@
-import { v4 as uuidv4 } from 'uuid'
 import cacheManager from 'cache-manager'
-import createLogger from '@meltwater/mlabs-logger'
-import { createConfigurationRepository } from '@meltwater/aws-configuration-fetcher'
+import { getConfig } from './get-config'
+import { createWrapper } from './wrapper'
 
-const createHandlerFactory = (parser, serializer, getCtx) => ({
+export const createHandlerFactory = (parser, serializer, getCtx) => ({
   configurationRequests,
   createFactories,
   createProcessor
@@ -19,57 +18,3 @@ const createHandlerFactory = (parser, serializer, getCtx) => ({
     return handle(event, context)
   }
 }
-
-const getConfig = (configurationRequests, cache, ctx) => {
-  const { log } = ctx
-  const configurationRepository = createConfigurationRepository({ cache, log })
-  return configurationRepository.getConfiguration(configurationRequests)
-}
-
-const getUniversalCtx = (event, context) => {
-  const reqId = uuidv4()
-  const { awsRequestId } = context
-
-  const logOutputMode =
-    process.env.IS_OFFLINE || process.env.IS_LOCAL ? 'pretty' : 'json'
-  const base = { reqId, awsRequestId }
-  const log = createLogger({
-    base,
-    outputMode: process.env.LOG_OUTPUT_MODE
-      ? process.env.LOG_OUTPUT_MODE
-      : logOutputMode
-  })
-
-  return {
-    reqId,
-    awsRequestId,
-    log
-  }
-}
-
-const createWrapper = (parser, serializer, ctx) => (processor) => async (
-  event,
-  context
-) => {
-  const { log } = ctx
-  try {
-    log.info({ meta: event }, 'start: handle')
-    const parsedEvent = parser(event, context)
-    const data = await processor(parsedEvent, context)
-    log.debug({ data }, 'data: handle')
-    const serializedData = serializer(data)
-    log.info('end: handle')
-    return serializedData
-  } catch (err) {
-    log.error({ err }, 'fail: handle')
-    throw err
-  }
-}
-
-const identity = (data) => data
-
-export const createJsonHandler = createHandlerFactory(
-  identity,
-  identity,
-  getUniversalCtx
-)

--- a/lib/handler/get-config.js
+++ b/lib/handler/get-config.js
@@ -1,0 +1,7 @@
+import { createConfigurationRepository } from '@meltwater/aws-configuration-fetcher'
+
+export const getConfig = (configurationRequests, cache, ctx) => {
+  const { log } = ctx
+  const configurationRepository = createConfigurationRepository({ cache, log })
+  return configurationRepository.getConfiguration(configurationRequests)
+}

--- a/lib/handler/get-context.js
+++ b/lib/handler/get-context.js
@@ -1,0 +1,23 @@
+import { v4 as uuidv4 } from 'uuid'
+import createLogger from '@meltwater/mlabs-logger'
+
+export const getUniversalCtx = (event, context) => {
+  const reqId = uuidv4()
+  const { awsRequestId } = context
+
+  const logOutputMode =
+    process.env.IS_OFFLINE || process.env.IS_LOCAL ? 'pretty' : 'json'
+  const base = { reqId, awsRequestId }
+  const log = createLogger({
+    base,
+    outputMode: process.env.LOG_OUTPUT_MODE
+      ? process.env.LOG_OUTPUT_MODE
+      : logOutputMode
+  })
+
+  return {
+    reqId,
+    awsRequestId,
+    log
+  }
+}

--- a/lib/handler/handle-json.js
+++ b/lib/handler/handle-json.js
@@ -1,0 +1,10 @@
+import { createHandlerFactory } from './factory'
+import { getUniversalCtx } from './get-context'
+
+const identity = (data) => data
+
+export const createJsonHandler = createHandlerFactory(
+  identity,
+  identity,
+  getUniversalCtx
+)

--- a/lib/handler/index.js
+++ b/lib/handler/index.js
@@ -1,1 +1,1 @@
-export * from './factory'
+export * from './handle-json'

--- a/lib/handler/wrapper.js
+++ b/lib/handler/wrapper.js
@@ -1,0 +1,18 @@
+export const createWrapper = (parser, serializer, ctx) => (processor) => async (
+  event,
+  context
+) => {
+  const { log } = ctx
+  try {
+    log.info({ meta: event }, 'start: handle')
+    const parsedEvent = parser(event, context)
+    const data = await processor(parsedEvent, context)
+    log.debug({ data }, 'data: handle')
+    const serializedData = serializer(data)
+    log.info('end: handle')
+    return serializedData
+  } catch (err) {
+    log.error({ err }, 'fail: handle')
+    throw err
+  }
+}


### PR DESCRIPTION
Broke our rule with the handle-json file name but figured when the number of handlers grow they are visually grouped apart from the util methods