### PR TITLE
RPT-326 Add putObjectJson to s3Client

### DIFF
--- a/lib/aws/s3.js
+++ b/lib/aws/s3.js
@@ -36,10 +36,11 @@ export class S3Client {
 
   /**
    * getObject from S3 Bucket
-   * @param {Object} key - The key to pass as the Key for s3Client.getObject
-   * @param {Object} params - Additional properties to the s3.getObject method
+   * @param {Object} key - The key to pass as the Key for s3Client.putObject
+   * @param {Object} body - The object to be stringified and passed as the Body for s3Client.putObject
+   * @param {Object} params - Additional properties to the s3.putObject method
    *
-   * @returns {*} - The JSON response from s3.getObject
+   * @returns {Promise<void>}
    */
   async putObjectJson(key, body, params = {}) {
     const log = this._log.child({

--- a/lib/aws/s3.js
+++ b/lib/aws/s3.js
@@ -41,6 +41,41 @@ export class S3Client {
    *
    * @returns {*} - The JSON response from s3.getObject
    */
+  async putObjectJson(key, body, params = {}) {
+    const log = this._log.child({
+      meta: { key, params },
+      method: 'puttObjectJson'
+    })
+    try {
+      log.info('start')
+
+      ac.assertNonWhiteSpaceString(key, argName({ key }))
+
+      const req = {
+        Body: JSON.stringify({
+          ...body,
+          reqId: this._reqId
+        }),
+        Key: key,
+        ...params
+      }
+
+      await this._s3.putObject(req).promise()
+
+      log.info('end')
+    } catch (err) {
+      log.error({ err }, 'fail')
+      throw err
+    }
+  }
+
+  /**
+   * getObject from S3 Bucket
+   * @param {Object} key - The key to pass as the Key for s3Client.getObject
+   * @param {Object} params - Additional properties to the s3.getObject method
+   *
+   * @returns {*} - The JSON response from s3.getObject
+   */
   async getObjectJson(key, params = {}) {
     const log = this._log.child({
       meta: { key, params },

--- a/lib/aws/s3.spec.js
+++ b/lib/aws/s3.spec.js
@@ -23,7 +23,35 @@ test('should pass bucket to AWS S3 client as Bucket', async (t) => {
   t.is(client._s3.config.params.Bucket, bucket)
 })
 
-test('should return payload', async (t) => {
+test('putObjectJson should append reqId to body', async (t) => {
+  const { createClient } = t.context
+  const client = createClient(t)
+  const body = { YAS: 'so good' }
+  const key = 'payload.json'
+
+  td.when(client._s3.putObject({
+    Body: JSON.stringify({
+      ...body,
+      reqId: 'a-req-id'
+    }),
+    Key: key
+  })).thenReturn({
+    promise: () => Promise.resolve({})
+  })
+
+  await client.putObjectJson(key, body)
+  t.pass()
+})
+
+test('putObjectJson should throw error if empty key', async (t) => {
+  const { createClient } = t.context
+  const client = createClient(t)
+  await t.throwsAsync(() => client.putObjectJson(), {
+    message: /key/i
+  })
+})
+
+test('getObjectJson should return payload', async (t) => {
   const { createClient } = t.context
   const client = createClient(t)
   const promise = td.function()
@@ -42,7 +70,7 @@ test('should return payload', async (t) => {
   t.deepEqual(res, payload)
 })
 
-test('should throw error if empty key', async (t) => {
+test('getObjectJson should throw error if empty key', async (t) => {
   const { createClient } = t.context
   const client = createClient(t)
   await t.throwsAsync(() => client.getObjectJson(), {
@@ -50,7 +78,7 @@ test('should throw error if empty key', async (t) => {
   })
 })
 
-test('should throw if Body is not parsable', async (t) => {
+test('getObjectJson should throw if Body is not parsable', async (t) => {
   const { createClient } = t.context
   const client = createClient(t)
   const promise = td.function()

--- a/lib/aws/s3.spec.js
+++ b/lib/aws/s3.spec.js
@@ -29,13 +29,15 @@ test('putObjectJson should append reqId to body', async (t) => {
   const body = { YAS: 'so good' }
   const key = 'payload.json'
 
-  td.when(client._s3.putObject({
-    Body: JSON.stringify({
-      ...body,
-      reqId: 'a-req-id'
-    }),
-    Key: key
-  })).thenReturn({
+  td.when(
+    client._s3.putObject({
+      Body: JSON.stringify({
+        ...body,
+        reqId: 'a-req-id'
+      }),
+      Key: key
+    })
+  ).thenReturn({
     promise: () => Promise.resolve({})
   })
 


### PR DESCRIPTION
This change introduces `s3Client.putObjectJson()`

Conforms to standards around `reqId` being a part of the written object, similar to `LambdaClient.invoke()`.