### PR TITLE
Add flexible query method to DynamodbocumentClient

### DIFF
--- a/lib/aws/dynamodb-document.js
+++ b/lib/aws/dynamodb-document.js
@@ -96,6 +96,24 @@ export class DynamodbDocumentClient {
     }
   }
 
+  async query(params) {
+    const log = this._log.child({
+      meta: { params },
+      method: 'query'
+    })
+    try {
+      log.info('start')
+      const res = await this._db.query(params).promise()
+      const data = res.Items
+      log.debug({ data }, 'data')
+      log.info('end')
+      return data
+    } catch (err) {
+      log.error({ err }, 'fail')
+      throw err
+    }
+  }
+
   async update(key, params = {}) {
     const log = this._log.child({
       ...this._getHashAndRangeKeyObj(key),

--- a/lib/aws/dynamodb-document.js
+++ b/lib/aws/dynamodb-document.js
@@ -104,7 +104,12 @@ export class DynamodbDocumentClient {
     try {
       log.info('start')
       const res = await this._db.query(params).promise()
-      const data = res.Items
+      const data = {
+        items: res.Items,
+        count: res.Count,
+        scannedCount: res.ScannedCount,
+        lastEvaluatedKey: res.LastEvaluatedKey
+      }
       log.debug({ data }, 'data')
       log.info('end')
       return data

--- a/lib/aws/dynamodb-document.spec.js
+++ b/lib/aws/dynamodb-document.spec.js
@@ -164,6 +164,28 @@ test('put should not validate rangeKey if not set', async (t) => {
   t.deepEqual(res, { more: 'stuff' })
 })
 
+test('query should return items', async (t) => {
+  const { createClient, hashKey } = t.context
+  const client = createClient(t)
+  const promise = td.function()
+  const params = {
+    KeyExpression: {
+      [hashKey]: {
+        ComparisonOperator: 'EQ',
+        AttributeValueList: ['foo']
+      }
+    }
+  }
+  td.when(
+    client._db.query(params)
+  ).thenReturn({ promise })
+  td.when(promise()).thenResolve({ Items: [{ some: 'stuff' }] })
+
+  const res = await client.query(params)
+
+  t.deepEqual(res[0], { some: 'stuff' })
+})
+
 test('update should return item', async (t) => {
   const { createClient, hashKey, rangeKey } = t.context
   const client = createClient(t)

--- a/lib/aws/dynamodb-document.spec.js
+++ b/lib/aws/dynamodb-document.spec.js
@@ -179,11 +179,12 @@ test('query should return items', async (t) => {
   td.when(
     client._db.query(params)
   ).thenReturn({ promise })
-  td.when(promise()).thenResolve({ Items: [{ some: 'stuff' }] })
+  const Items = [{ some: 'stuff' }]
+  td.when(promise()).thenResolve({ Items })
 
-  const res = await client.query(params)
+  const { items } = await client.query(params)
 
-  t.deepEqual(res[0], { some: 'stuff' })
+  t.deepEqual(items, items)
 })
 
 test('update should return item', async (t) => {


### PR DESCRIPTION
Wanted to leave this pretty flexible with the query params.
Leaving out KeyExpression does mean its user error prone but unsure if forcing KeyExpression is a good idea